### PR TITLE
Move from error-chain to failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1666,7 +1666,7 @@ dependencies = [
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "jenkins_api 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1691,7 +1691,7 @@ version = "0.74.0"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.4 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/shipcat_cli/Cargo.toml
+++ b/shipcat_cli/Cargo.toml
@@ -23,7 +23,7 @@ path = "src/main.rs"
 [dependencies]
 shipcat_definitions = { path = "../shipcat_definitions", features = ["filesystem"] }
 clap = "2.31.2"
-error-chain = "0.12.0"
+failure = "0.1.3"
 log = "0.4.5"
 loggerv = "0.7.1"
 openssl-probe = "0.1.2"
@@ -40,6 +40,7 @@ chrono = { version = "0.4.6", features = ["serde"] }
 semver = { version = "0.9.0", features = ["serde"] }
 dirs = "1.0.3"
 libc = "0.2.43"
+
 
 [dependencies.petgraph]
 features = ["serde-1"]

--- a/shipcat_cli/src/helm/mod.rs
+++ b/shipcat_cli/src/helm/mod.rs
@@ -1,5 +1,53 @@
 /// Allow normal error handling from structs
-pub use super::{Result, ResultExt, ErrorKind, Error};
+
+// New failure error type
+#[derive(Debug)]
+struct HError {
+    inner: Context<HErrKind>,
+}
+// its associated enum
+#[derive(Clone, Eq, PartialEq, Debug, Fail)]
+enum HErrKind {
+    #[fail(display = "{} has no version in manifest and is not installed yes", _0)]
+    MissingRollingVersion(String),
+
+    #[fail(display = "manifest key '{}' was not propagated internally - bug!", _0)]
+    ManifestFailure(String),
+
+    #[fail(display = "Helm upgrade of '{}' failed", _0)]
+    HelmUpgradeFailure(String),
+
+    #[fail(display = "{} upgrade timed out waiting{}s for deployment(s) to come online", _0, _1)]
+    UpgradeTimeout(String, u32),
+}
+use failure::{Error, Fail, Context, Backtrace, ResultExt};
+use std::fmt::{self, Display};
+
+// boilerplate error wrapping (might go away)
+impl Fail for HError {
+    fn cause(&self) -> Option<&Fail> { self.inner.cause() }
+    fn backtrace(&self) -> Option<&Backtrace> { self.inner.backtrace() }
+}
+impl Display for HError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        Display::fmt(&self.inner, f)
+    }
+}
+impl From<HErrKind> for HError {
+    fn from(kind: HErrKind) -> HError {
+        HError { inner: Context::new(kind) }
+    }
+}
+impl From<Context<HErrKind>> for HError {
+    fn from(inner: Context<HErrKind>) -> HError {
+        HError { inner: inner }
+    }
+}
+pub type Result<T> = std::result::Result<T, Error>;
+
+
+
+
 /// Verify trait gets the Config
 pub use super::{Config, Region, VersionScheme};
 /// Need basic manifest handling

--- a/shipcat_cli/src/lib.rs
+++ b/shipcat_cli/src/lib.rs
@@ -35,89 +35,10 @@ extern crate semver;
 // parallel upgrades:
 extern crate threadpool;
 
-#[macro_use]
-extern crate error_chain;
-error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
-    }
-    links {}
-    foreign_links {
-        Fmt(::std::fmt::Error);
-        Io(::std::io::Error) #[cfg(unix)];
-        Float(::std::num::ParseFloatError);
-        Int(::std::num::ParseIntError);
-        Mani(shipcat_definitions::Error);
-        SerdeY(serde_yaml::Error);
-        SerdeJ(serde_json::Error);
-        Slack(slack_hook::Error);
-        Reqw(reqwest::UrlError);
-        Reqe(reqwest::Error);
-        Time(::std::time::SystemTimeError);
-    }
-    errors {
-        MissingJenkinsJob(job: String) {
-            description("Jenkins job could not be fetched")
-            display("Failed to get jenkins job {}", job)
-        }
-        JenkinsFailure {
-            description("Jenkins client configuration failure")
-            display("Failed to create jenkins client")
-        }
-        MissingSlackUrl {
-            description("SLACK_SHIPCAT_HOOK_URL not specified")
-            display("SLACK_SHIPCAT_HOOK_URL not specified")
-        }
-        MissingSlackChannel {
-            description("SLACK_SHIPCAT_CHANNEL not specified")
-            display("SLACK_SHIPCAT_CHANNEL not specified")
-        }
-        MissingGrafanaUrl {
-            description("GRAFANA_SHIPCAT_HOOK_URL not specified")
-            display("GRAFANA_SHIPCAT_HOOK_URL not specified")
-        }
-        MissingGrafanaToken {
-            description("GRAFANA_SHIPCAT_TOKEN not specified")
-            display("GRAFANA_SHIPCAT_TOKEN not specified")
-        }
-        MissingJenkinsUrl {
-            description("JENKINS_API_URL not specified")
-            display("JENKINS_API_URL not specified")
-        }
-        MissingJenkinsUser {
-            description("JENKINS_API_USER not specified")
-            display("JENKINS_API_USER not specified")
-        }
-        UnexpectedHttpStatus(status: reqwest::StatusCode) {
-            description("unexpected HTTP status")
-            display("unexpected HTTP status: {}", &status)
-        }
-        Url(url: reqwest::Url) {
-            description("could not access URL")
-            display("could not access URL '{}'", &url)
-        }
-        MissingRollingVersion(svc: String) {
-            description("missing version for install")
-            display("{} has no version in manifest and is not installed yes", &svc)
-        }
-        ManifestFailure(key: String) {
-            description("Manifest key not propagated correctly internally")
-            display("manifest key {} was not propagated internally - bug!", &key)
-        }
-        HelmUpgradeFailure(svc: String) {
-            description("Helm upgrade call failed")
-            display("Helm upgrade of {} failed", &svc)
-        }
-        UpgradeTimeout(svc: String, secs: u32) {
-            description("upgrade timed out")
-            display("{} upgrade timed out waiting {}s for deployment(s) to come online", &svc, secs)
-        }
-        SlackSendFailure(hook: String) {
-            description("slack message send failed")
-            display("Failed to send the slack message to '{}' ", &hook)
-        }
-    }
-}
+#[macro_use] extern crate failure;
+
+pub use failure::Error; //Fail
+pub type Result<T> = std::result::Result<T, Error>;
 
 extern crate shipcat_definitions;
 pub use shipcat_definitions::{Manifest, ConfigType};

--- a/shipcat_cli/src/main.rs
+++ b/shipcat_cli/src/main.rs
@@ -4,6 +4,7 @@ extern crate clap;
 extern crate log;
 extern crate loggerv;
 extern crate libc;
+//extern crate failure;
 
 extern crate shipcat;
 
@@ -14,6 +15,7 @@ use shipcat::*;
 use clap::{Arg, App, AppSettings, SubCommand, ArgMatches};
 use std::process;
 
+
 fn print_error_debug(e: &Error) {
     use std::env;
     // print causes of error if present
@@ -22,9 +24,15 @@ fn print_error_debug(e: &Error) {
         // only print debug implementation rather than unwinding
         warn!("{:?}", e);
     } else {
-        // normal case - unwind the error chain
-        for e in e.iter().skip(1) {
-            warn!("caused by: {}", e);
+        // normal case - unwind the failure chain
+        for cause in e.iter_chain().skip(1) {
+            //if let Some(err) = cause.downcast_ref::<SyncFailure<tera::Error>>() {
+            //    warn!("caused by {}", err);
+            //} else {
+                // can read cause normally
+                warn!("caused by: {}", cause);
+                warn!("{:?}", cause); // debug for error-chain traces etc
+            //}
         }
     }
 }

--- a/shipcat_definitions/Cargo.toml
+++ b/shipcat_definitions/Cargo.toml
@@ -28,12 +28,12 @@ serde_yaml = "0.8.5"
 tera = "0.11.16"
 semver = { version = "0.9.0", features = ["serde"] }
 base64 = "0.9.3"
-error-chain = "0.12.0"
 reqwest = "0.9.4"
 serde_json = "1.0.32"
 dirs = { version = "1.0.4", optional = true }
 walkdir = { version = "2.2.5", optional = true }
 static_assertions = "0.3.1"
+failure = "0.1.3"
 
 [features]
 default = []

--- a/shipcat_definitions/src/config.rs
+++ b/shipcat_definitions/src/config.rs
@@ -14,6 +14,7 @@ use super::{Result, Error};
 use super::structs::{Contact};
 use states::ConfigType;
 use region::Region;
+use failure::Fail;
 
 // ----------------------------------------------------------------------------------
 
@@ -380,7 +381,7 @@ impl Config {
                         if let Ok(expected) = Version::parse(&caps["version"]) {
                             let res2 = Config::verify_version(&expected);
                             if let Err(e2) = res2 {
-                                return Err(Error::from(e).chain_err(|| e2));
+                                return Err(e.context(e2))?;
                             }
                         }
                     }

--- a/shipcat_definitions/src/lib.rs
+++ b/shipcat_definitions/src/lib.rs
@@ -1,4 +1,3 @@
-#![recursion_limit = "1024"]
 #![allow(renamed_and_removed_lints)]
 #![allow(non_snake_case)]
 
@@ -27,6 +26,11 @@ extern crate regex;
 extern crate semver;
 extern crate base64;
 
+#[macro_use] extern crate failure;
+
+pub use failure::Error; //Fail
+pub type Result<T> = std::result::Result<T, Error>;
+
 // Mutually exclusive backing on hold atm..
 // currently breaks Default for ConfigType and ManifestType
 //#[macro_use]
@@ -35,64 +39,6 @@ extern crate base64;
 //                any(    feature = "filesystem", feature = "crd")),
 //            "Must exclusively use Filesystem or CRDs as the backing");
 
-#[macro_use]
-extern crate error_chain;
-error_chain! {
-    types {
-        Error, ErrorKind, ResultExt, Result;
-    }
-    links {}
-    foreign_links {
-        Fmt(::std::fmt::Error);
-        Io(::std::io::Error) #[cfg(unix)];
-        Float(::std::num::ParseFloatError);
-        Int(::std::num::ParseIntError);
-        Tmpl(tera::Error);
-        SerdeY(serde_yaml::Error);
-        SerdeJ(serde_json::Error);
-        Reqw(reqwest::UrlError);
-        Reqe(reqwest::Error);
-        Time(::std::time::SystemTimeError);
-    }
-    errors {
-        MissingVaultAddr {
-            description("VAULT_ADDR not specified")
-            display("VAULT_ADDR not specified")
-        }
-        MissingVaultToken {
-            description("VAULT_TOKEN not specified")
-            display("VAULT_TOKEN not specified")
-        }
-        UnexpectedHttpStatus(status: reqwest::StatusCode) {
-            description("unexpected HTTP status")
-            display("unexpected HTTP status: {}", &status)
-        }
-        NoHomeDirectory {
-            description("can't find home directory")
-            display("can't find home directory")
-        }
-        Url(url: reqwest::Url) {
-            description("could not access URL")
-            display("could not access URL '{}'", &url)
-        }
-        InvalidTemplate(svc: String) {
-            description("invalid template")
-            display("service '{}' has invalid templates", svc)
-        }
-        InvalidManifest(svc: String) {
-            description("manifest does not validate")
-            display("manifest for {} does not validate", &svc)
-        }
-        InvalidSecretForm(key: String) {
-            description("secret is of incorrect form")
-            display("secret '{}' not have the 'value' key", &key)
-        }
-        SecretNotAccessible(key: String) {
-            description("secret could not be reached or accessed")
-            display("secret '{}'", &key)
-        }
-    }
-}
 
 /// Config with regional data
 pub mod region;

--- a/shipcat_definitions/src/structs/metadata.rs
+++ b/shipcat_definitions/src/structs/metadata.rs
@@ -1,8 +1,10 @@
+use template::TeraError;
 use regex::Regex;
 use std::ops::{Deref, DerefMut};
 
 use super::Result;
 use config::{Team, SlackParameters};
+
 
 /// Contact data
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -113,10 +115,10 @@ impl Metadata {
         use tera::{Tera, Context};
         let mut ctx = Context::new();
         ctx.insert("version", &ver.to_string());
-        let res = Tera::one_off(&self.gitTagTemplate, &ctx, false).map_err(|e| {
-            warn!("Failed to template gitTagTemplate {}", self.gitTagTemplate);
-            e
-        })?;
+        let res = Tera::one_off(&self.gitTagTemplate, &ctx, false)
+            .map_err(|e| TeraError::new(e,
+                format!("Failed to template gitTagTemplate {}", self.gitTagTemplate)
+            ))?;
         Ok(res)
     }
 }

--- a/shipcat_definitions/src/structs/metadata.rs
+++ b/shipcat_definitions/src/structs/metadata.rs
@@ -1,9 +1,10 @@
-use template::TeraError;
+//use template::TeraError;
 use regex::Regex;
 use std::ops::{Deref, DerefMut};
 
 use super::Result;
 use config::{Team, SlackParameters};
+use failure::{SyncFailure, ResultExt};
 
 
 /// Contact data
@@ -116,9 +117,8 @@ impl Metadata {
         let mut ctx = Context::new();
         ctx.insert("version", &ver.to_string());
         let res = Tera::one_off(&self.gitTagTemplate, &ctx, false)
-            .map_err(|e| TeraError::new(e,
-                format!("Failed to template gitTagTemplate {}", self.gitTagTemplate)
-            ))?;
+            .map_err(SyncFailure::new)
+            .context(format_err!("Failed to template gitTagTemplate {}", self.gitTagTemplate))?;
         Ok(res)
     }
 }


### PR DESCRIPTION
This  was a bit of a yak that needed to be shaved to see if it was helping my `!Sync` serde errors. But don't think I actually need this. Yet. It's certainly pretty awkward in the current form, although it does have more potential than error-chain.

Stashing it here for now. Comments welcome, but this is likely going to linger for a while until `failure` stabilizes.