### PR TITLE
[SREAI-45] adds metadata to the shipcat template context

### DIFF
--- a/shipcat_definitions/src/template.rs
+++ b/shipcat_definitions/src/template.rs
@@ -85,6 +85,7 @@ impl Manifest {
         ctx.insert("kong", &reg.kong);
         ctx.insert("cluster", &reg.cluster.clone());
         ctx.insert("namespace", &reg.namespace.clone());
+        ctx.insert("metadata", &self.metadata.clone());
         Ok(ctx)
     }
 


### PR DESCRIPTION
Needed shipcat definition in order to push labels with the new relic configuration as defined at 

https://github.com/babylonhealth/manifests/pull/35162/files